### PR TITLE
Have an implicit instance for Equivalent classes, (A === B)

### DIFF
--- a/core/src/main/scala/Pickler.scala
+++ b/core/src/main/scala/Pickler.scala
@@ -2,6 +2,7 @@ package gkit
 
 import scalaz._
 import Leibniz.===
+import Liskov.<~<
 import scalaz.syntax.std.option._
 import scalaz.syntax.either._
 
@@ -14,18 +15,30 @@ trait Pickler[A, B] {
 
   def unpickle(b: B, path: List[String] = Nil): String \/ A
 
+}
+
+object Pickler extends LowerPriorityPickler {
   implicit def leibPickler[A, B](implicit f: A === B): Pickler[A, B] = new Pickler[A, B] {
     def pickle(a: A): B =  f(a)
     def unpickle(b: B, path: List[String]): String \/ A = Leibniz.symm[Nothing, Any, A, B](f)(b).right
   }
 
-  class Typecheck[A] {
-    def apply[B, C](b: B, path: List[String])(f: A => C)
-      (implicit tpble: Typeable[A], tm: Manifest[A]): String \/ C = {
-      def errMsg = s"""type mismatch at `${path.mkString(".")}': expected: ${tm.runtimeClass.getName}, found: ${b.toString}"""
-      b.cast[A].cata(f(_).right, errMsg.left)
-    }
+}
+
+trait LowerPriorityPickler {
+  implicit def liskovPickler[A, B](implicit f: A <~< B, tpble: Typeable[A], tm: Manifest[A]): Pickler[A, B] = new Pickler[A, B] {
+    def pickle(a: A): B =  f(a)
+    def unpickle(b: B, path: List[String]): String \/ A =
+      typecheck[A](b, path)(identity)
   }
 
   def typecheck[A]: Typecheck[A] = new Typecheck[A]
+}
+
+class Typecheck[A] {
+  def apply[B, C](b: B, path: List[String])(f: A => C)
+    (implicit tpble: Typeable[A], tm: Manifest[A]): String \/ C = {
+    def errMsg = s"""type mismatch at `${path.mkString(".")}': expected: ${tm.runtimeClass.getName}, found: ${b.toString}"""
+    b.cast[A].cata(f(_).right, errMsg.left)
+  }
 }

--- a/mongo/src/main/scala/BSONPickler.scala
+++ b/mongo/src/main/scala/BSONPickler.scala
@@ -17,9 +17,8 @@ import scalaz.syntax.traverse._
 import shapeless._
 import shapeless.record._
 
-trait BSONPickler[A] extends Pickler[A, BSONValue]
-
 object BSONPickler {
+  import Pickler._
 
   implicit def apply[A](implicit ev: LabelledTypeClass[BSONPickler]): BSONPickler[A] =
     macro GenericMacros.deriveLabelledInstance[BSONPickler, A]
@@ -54,18 +53,6 @@ object BSONPickler {
     def pickle(dt: DateTime): BSONValue = BSONDateTime(dt.getMillis)
     def unpickle(v: BSONValue, path: List[String]): String \/ DateTime =
       typecheck[BSONDateTime](v, path)(dt => new DateTime(dt.value))
-  }
-
-  implicit def BSONObjectIDPickler: BSONPickler[BSONObjectID] = new BSONPickler[BSONObjectID] {
-    def pickle(boid: BSONObjectID): BSONValue = boid
-    def unpickle(v: BSONValue, path: List[String]): String \/ BSONObjectID =
-      typecheck[BSONObjectID](v, path)(identity)
-  }
-
-  implicit def BSONDocumentPickler: BSONPickler[BSONDocument] = new BSONPickler[BSONDocument] {
-    def pickle(doc: BSONDocument): BSONValue = doc
-    def unpickle(v: BSONValue, path: List[String]): String \/ BSONDocument =
-      typecheck[BSONDocument](v, path)(identity)
   }
 
   implicit def OptionBSONPickler[T](implicit bp: BSONPickler[T]): BSONPickler[Option[T]] = new BSONPickler[Option[T]] {

--- a/mongo/src/main/scala/package.scala
+++ b/mongo/src/main/scala/package.scala
@@ -1,3 +1,7 @@
 package gkit
 
-package object mongo extends QueryPicklerInstances with GeneratorInstances
+import reactivemongo.bson.BSONValue
+
+package object mongo extends QueryPicklerInstances with GeneratorInstances {
+  type BSONPickler[A] = Pickler[A, BSONValue]
+}

--- a/play-gjson/src/main/scala/JSONPickler.scala
+++ b/play-gjson/src/main/scala/JSONPickler.scala
@@ -17,9 +17,12 @@ import scalaz.syntax.traverse._
 import shapeless._
 import shapeless.record._
 
-trait JSONPickler[A] extends Pickler[A, JsValue]
+object `package` {
+  type JSONPickler[A] = Pickler[A, JsValue]
+}
 
 object JSONPickler {
+  import Pickler._
 
   implicit def apply[A](implicit ev: LabelledTypeClass[JSONPickler]): JSONPickler[A] =
     macro GenericMacros.deriveLabelledInstance[JSONPickler, A]

--- a/play-gresource-mongo/src/main/scala/PicklerInstances.scala
+++ b/play-gresource-mongo/src/main/scala/PicklerInstances.scala
@@ -11,6 +11,7 @@ import scalaz.syntax.either._
 import scalaz.syntax.std.option._
 
 trait PicklerInstances {
+  import gkit.Pickler._
 
   implicit def BSONObjectIDPickler: JSONPickler[BSONObjectID] =
     new JSONPickler[BSONObjectID] {


### PR DESCRIPTION
This makes it unnecessary to make NOOP pickers such as: 

``` scala
  implicit def BSONValuePickler: BSONPickler[BSONValue] = new BSONPickler[BSONValue] {
    def pickle(doc: BSONValue): BSONValue = doc
    def unpickle(v: BSONValue, path: List[String]): String \/ BSONValue =
      typecheck[BSONValue](v, path)(identity)
  } 
```
